### PR TITLE
Handle tenant name with spaces

### DIFF
--- a/src/pages/TodosPage.tsx
+++ b/src/pages/TodosPage.tsx
@@ -8,7 +8,7 @@ const client = generateClient<Schema>()
 export const loader = async ({ request }: { request: Request }) => {
 	let attrs
 	const url = new URL(request.url)
-	const tenantNameInURL = url.pathname.split('/')[1]
+	const tenantNameInURL = decodeURI(url.pathname.split('/')[1])
 	console.log('tenantNameInURL', tenantNameInURL)
 	try {
 		attrs = await fetchUserAttributes()


### PR DESCRIPTION
Tenant names with spaces get a %20 encoding on the URL. This fails the test to see whether the tenantName on the URL equals the `custom:tenantName` custom attribute in Cognito. 